### PR TITLE
Use Game Object Ids for passing game objects through IPC

### DIFF
--- a/CustomizePlus/Api/CustomizePlusIpc.General.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.General.cs
@@ -4,7 +4,7 @@ namespace CustomizePlus.Api;
 
 public partial class CustomizePlusIpc
 {
-    private readonly (int Breaking, int Feature) _apiVersion = (4, 0);
+    private readonly (int Breaking, int Feature) _apiVersion = (5, 0);
 
     /// <summary>
     /// When there are breaking changes the first number is bumped up and second one is reset.

--- a/CustomizePlus/Api/CustomizePlusIpc.Profile.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.Profile.cs
@@ -154,7 +154,7 @@ public partial class CustomizePlusIpc
             return ((int)ErrorCode.InvalidCharacter, null);
 
         var actor = (Actor)character.Address;
-        if (!actor.Valid)
+        if (!actor.Valid || !actor.IsCharacter)
             return ((int)ErrorCode.InvalidCharacter, null);
 
         try
@@ -202,7 +202,7 @@ public partial class CustomizePlusIpc
             return (int)ErrorCode.InvalidCharacter;
 
         var actor = (Actor)character.Address;
-        if (!actor.Valid)
+        if (!actor.Valid || !actor.IsCharacter)
             return (int)ErrorCode.InvalidCharacter;
 
         try

--- a/CustomizePlus/Api/CustomizePlusIpc.Profile.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.Profile.cs
@@ -30,7 +30,7 @@ public partial class CustomizePlusIpc
     /// /!\ If no profile is set on specified character profile id will be equal to Guid.Empty
     /// </summary>
     [EzIPCEvent("Profile.OnUpdate")]
-    private Action<ICharacter, Guid> OnProfileUpdate;
+    private Action<ulong, Guid> OnProfileUpdate;
 
     /// <summary>
     /// Retrieve list of all user profiles
@@ -125,10 +125,9 @@ public partial class CustomizePlusIpc
     /// Get unique id of currently active profile for character.
     /// </summary>
     [EzIPC("Profile.GetActiveProfileIdOnCharacter")]
-    private (int, Guid?) GetActiveProfileIdOnCharacter(ICharacter character)
+    private (int, Guid?) GetActiveProfileIdOnCharacter(ulong characterObjectId)
     {
-        //todo: temporary
-        return ((int)ErrorCode.UnknownError, null);
+        var character = (ICharacter?)_gameObjectService.GetGameObjectById(characterObjectId);
 
         if (character == null)
             return ((int)ErrorCode.InvalidCharacter, null);
@@ -146,10 +145,9 @@ public partial class CustomizePlusIpc
     /// Returns profile's unique id which can be used to manipulate it at a later date.
     /// </summary>
     [EzIPC("Profile.SetTemporaryProfileOnCharacter")]
-    private (int, Guid?) SetTemporaryProfileOnCharacter(ICharacter character, string profileJson)
+    private (int, Guid?) SetTemporaryProfileOnCharacter(ulong characterObjectId, string profileJson)
     {
-        //todo: temporary
-        return ((int)ErrorCode.UnknownError, null);
+        var character = (ICharacter?)_gameObjectService.GetGameObjectById(characterObjectId);
 
         //todo: do not allow to set temporary profile on reserved actors (examine, etc)
         if (character == null)
@@ -196,10 +194,9 @@ public partial class CustomizePlusIpc
     /// Delete temporary profile currently active on character
     /// </summary>
     [EzIPC("Profile.DeleteTemporaryProfileOnCharacter")]
-    private int DeleteTemporaryProfileOnCharacter(ICharacter character)
+    private int DeleteTemporaryProfileOnCharacter(ulong characterObjectId)
     {
-        //todo: temporary
-        return (int)ErrorCode.UnknownError;
+        var character = (ICharacter?)_gameObjectService.GetGameObjectById(characterObjectId);
 
         if (character == null)
             return (int)ErrorCode.InvalidCharacter;
@@ -339,6 +336,6 @@ public partial class CustomizePlusIpc
 
         _logger.Debug($"Sending player update message: Character: {character.Name.ToString().Incognify()}, Profile: {(profile != null ? profile.ToString() : "no profile")}");
 
-        OnProfileUpdate(character, profile != null ? profile.UniqueId : Guid.Empty);
+        OnProfileUpdate(character.GameObjectId, profile != null ? profile.UniqueId : Guid.Empty);
     }
 }

--- a/CustomizePlus/Game/Services/GameObjectService.cs
+++ b/CustomizePlus/Game/Services/GameObjectService.cs
@@ -56,6 +56,11 @@ public class GameObjectService
                 || actor == _objectTable.GetObjectAddress(0));
     }
 
+    public DalamudGameObject? GetGameObjectById(ulong id)
+    {
+        return _objectTable.SearchById(id);
+    }
+
     /// <summary>
     /// Case sensitive
     /// </summary>


### PR DESCRIPTION
fixes #15 

As the title indicates, this change uses game object ids instead of serialized representations of game objects, for the arguments to several ipc endpoints.
The valid endpoint still returns false, and is planned to until this is reviewed.
`OnArmatureChanged` has not been re-enabled as the reason for it being disabled seems out of the scope of this PR.
This has been tested in game using the ipc testing tab, with endpoints appearing to behave as expected, but given my only experience is the current state that may not be the case.