### PR TITLE
Add Profile IPC for setting priority, enabled state, or both.

### DIFF
--- a/CustomizePlus/Api/CustomizePlusIpc.General.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.General.cs
@@ -4,7 +4,7 @@ namespace CustomizePlus.Api;
 
 public partial class CustomizePlusIpc
 {
-    private readonly (int Breaking, int Feature) _apiVersion = (6, 2);
+    private readonly (int Breaking, int Feature) _apiVersion = (6, 3);
 
     /// <summary>
     /// When there are breaking changes the first number is bumped up and second one is reset.

--- a/CustomizePlus/Api/CustomizePlusIpc.Profile.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.Profile.cs
@@ -17,7 +17,6 @@ using Penumbra.GameData.Structs;
 using Penumbra.GameData.Enums;
 using CustomizePlus.Templates.Data;
 using CustomizePlus.Templates.Events;
-using OtterGui.Extensions;
 using Penumbra.GameData.Actors;
 using Penumbra.String;
 
@@ -171,6 +170,45 @@ public partial class CustomizePlusIpc
         return (int)SetProfileStateInternal(uniqueId, false);
     }
 
+    /// <summary>
+    /// Set profile priority by Unique ID. Does not work on temporary profiles.
+    /// </summary>
+    [EzIPC("Profile.SetPriorityByUniqueId")]
+    private int SetProfilePriorityByUniqueId(Guid uniqueId, int priority)
+    {
+        return (int)SetProfileStateInternal(uniqueId, priority);
+    }
+
+    /// <summary>
+    /// General purpose state changer for state and priority by its Unique ID. Does not work on temporary profiles.
+    /// </summary>
+    [EzIPC("Profile.SetStateByUniqueId")]
+    private int SetProfileStateByUniqueId(Guid uniqueId, bool state, int priority)
+    {
+        return (int)SetProfileStateInternal(uniqueId, state, priority);
+    }
+
+    private ErrorCode SetProfileStateInternal(Guid uniqueId, bool state, int priority)
+    {
+        if (uniqueId == Guid.Empty)
+            return ErrorCode.ProfileNotFound;
+
+        try
+        {
+            _profileManager.SetProfileState(uniqueId, state, priority);
+            return ErrorCode.Success;
+        }
+        catch (ProfileNotFoundException)
+        {
+            return ErrorCode.ProfileNotFound;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Exception in SetProfileStateInternal. Unique id: {uniqueId}, state: {state}, priority: {priority}, exception: {ex}.");
+            return ErrorCode.UnknownError;
+        }
+    }
+
     private ErrorCode SetProfileStateInternal(Guid uniqueId, bool state)
     {
         if (uniqueId == Guid.Empty)
@@ -181,13 +219,34 @@ public partial class CustomizePlusIpc
             _profileManager.SetEnabled(uniqueId, state);
             return ErrorCode.Success;
         }
-        catch (ProfileNotFoundException ex)
+        catch (ProfileNotFoundException)
         {
             return ErrorCode.ProfileNotFound;
         }
         catch (Exception ex)
         {
             _logger.Error($"Exception in SetProfileStateInternal. Unique id: {uniqueId}, state: {state}, exception: {ex}.");
+            return ErrorCode.UnknownError;
+        }
+    }
+
+    private ErrorCode SetProfileStateInternal(Guid uniqueId, int priority)
+    {
+        if (uniqueId == Guid.Empty)
+            return ErrorCode.ProfileNotFound;
+
+        try
+        {
+            _profileManager.SetPriority(uniqueId, priority);
+            return ErrorCode.Success;
+        }
+        catch (ProfileNotFoundException)
+        {
+            return ErrorCode.ProfileNotFound;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Exception in SetProfileStateInternal. Unique id: {uniqueId}, priority: {priority}, exception: {ex}.");
             return ErrorCode.UnknownError;
         }
     }

--- a/CustomizePlus/Profiles/ProfileManager.cs
+++ b/CustomizePlus/Profiles/ProfileManager.cs
@@ -253,12 +253,10 @@ public partial class ProfileManager : IDisposable
     public void SetEnabled(Guid guid, bool value)
     {
         var profile = Profiles.FirstOrDefault(x => x.UniqueId == guid && x.ProfileType == ProfileType.Normal);
-        if (profile != null)
-        {
-            SetEnabled(profile, value);
-        }
-        else
+        if (profile == null)
             throw new ProfileNotFoundException();
+
+        SetEnabled(profile, value);
     }
 
     public void SetPriority(Profile profile, int value)
@@ -274,6 +272,26 @@ public partial class ProfileManager : IDisposable
         SaveProfile(profile);
 
         _event.Invoke(ProfileChanged.Type.PriorityChanged, profile, value);
+    }
+
+    public void SetPriority(Guid guid, int value)
+    {
+        var profile = Profiles.FirstOrDefault(x => x.UniqueId == guid && x.ProfileType == ProfileType.Normal);
+        if (profile == null)
+            throw new ProfileNotFoundException();
+
+        SetPriority(profile, value);
+    }
+
+    public void SetProfileState(Guid guid, bool state, int priority)
+    {
+        var profile = Profiles.FirstOrDefault(x => x.UniqueId == guid && x.ProfileType == ProfileType.Normal);
+        if (profile == null)
+            throw new ProfileNotFoundException();
+        // could do the checks for priority and enabled state in here to avoid a double save,
+        // but assume this is more preferred for clarity.
+        SetEnabled(profile, state);
+        SetPriority(profile, priority);
     }
 
     public void DeleteTemplate(Profile profile, int templateIndex)

--- a/CustomizePlus/UI/Windows/MainWindow/Tabs/Debug/IPCTestTab.cs
+++ b/CustomizePlus/UI/Windows/MainWindow/Tabs/Debug/IPCTestTab.cs
@@ -1,19 +1,14 @@
-﻿using Dalamud.Game.ClientState.Objects.Types;
-using Dalamud.Plugin;
-using Dalamud.Plugin.Ipc;
+﻿using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using Dalamud.Bindings.ImGui;
 using Newtonsoft.Json;
 using OtterGui.Raii;
 using System.Linq;
 using CustomizePlus.Profiles;
-using CustomizePlus.Configuration.Helpers;
 using CustomizePlus.Game.Services;
-using CustomizePlus.GameData.Services;
 using Penumbra.GameData.Actors;
 using ECommonsLite.EzIpcManager;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using OtterGui.Log;
 using CustomizePlus.Core.Extensions;
@@ -55,6 +50,12 @@ public class IPCTestTab //: IDisposable
     [EzIPC("Profile.DisableByUniqueId")]
     private readonly Func<Guid, int> _disableProfileByUniqueIdIpcFunc;
 
+    [EzIPC("Profile.SetPriorityByUniqueId")]
+    private readonly Func<Guid, int, int> _setPriorityByUniqueIdIpcFunc;
+
+    [EzIPC("Profile.SetStateByUniqueId")]
+    private readonly Func<Guid, bool, int, int> _setStateByUniqueIdIpcFunc;
+
     [EzIPC("Profile.GetActiveProfileIdOnCharacter")]
     private readonly Func<ushort, (int, Guid?)> _getActiveProfileIdOnCharacterIpcFunc;
 
@@ -91,6 +92,7 @@ public class IPCTestTab //: IDisposable
     private string? _targetCharacterName;
 
     private string _targetProfileId = "";
+    private int _targetProfilePriority = 0;
 
     private int _cutsceneActorIdx;
     private int _cutsceneActorParentIdx;
@@ -325,6 +327,48 @@ public class IPCTestTab //: IDisposable
             else
             {
                 _logger.Error($"Error code {result} while calling DisableByUniqueId");
+                _popupSystem.ShowPopup(PopupSystem.Messages.ActionError);
+            }
+        }
+
+        if (ImGui.Button("Set profile priority by Unique ID"))
+        {
+            int result = _setPriorityByUniqueIdIpcFunc(Guid.Parse(_targetProfileId), _targetProfilePriority);
+            if (result == 0)
+            {
+                _popupSystem.ShowPopup(PopupSystem.Messages.IPCSetPriorityByIdDone);
+            }
+            else
+            {
+                _logger.Error($"Error code {result} while calling SetPriorityByUniqueId");
+                _popupSystem.ShowPopup(PopupSystem.Messages.ActionError);
+            }
+        }
+
+        if (ImGui.Button("Enable profile state by ID and Priority"))
+        {
+            int result = _setStateByUniqueIdIpcFunc(Guid.Parse(_targetProfileId), true, _targetProfilePriority);
+            if (result == 0)
+            {
+                _popupSystem.ShowPopup(PopupSystem.Messages.IPCSetStateByIdDone);
+            }
+            else
+            {
+                _logger.Error($"Error code {result} while calling SetProfileByUniqueId");
+                _popupSystem.ShowPopup(PopupSystem.Messages.ActionError);
+            }
+        }
+
+        if (ImGui.Button("Disable profile state by ID and priority"))
+        {
+            int result = _setStateByUniqueIdIpcFunc(Guid.Parse(_targetProfileId), false, _targetProfilePriority);
+            if (result == 0)
+            {
+                _popupSystem.ShowPopup(PopupSystem.Messages.IPCSetStateByIdDone);
+            }
+            else
+            {
+                _logger.Error($"Error code {result} while calling SetProfileByUniqueId");
                 _popupSystem.ShowPopup(PopupSystem.Messages.ActionError);
             }
         }

--- a/CustomizePlus/UI/Windows/PopupSystem.Messages.cs
+++ b/CustomizePlus/UI/Windows/PopupSystem.Messages.cs
@@ -1,5 +1,4 @@
-﻿using CustomizePlus.Core.Services.Dalamud;
-using System.Numerics;
+﻿using System.Numerics;
 
 namespace CustomizePlus.UI.Windows;
 
@@ -20,6 +19,8 @@ public partial class PopupSystem
         public const string IPCSuccessfullyExecuted = "ipc_successfully_executed";
         public const string IPCEnableProfileByIdDone = "ipc_enable_profile_by_id_done";
         public const string IPCDisableProfileByIdDone = "ipc_disable_profile_by_id_done";
+        public const string IPCSetPriorityByIdDone = "ipc_set_priority_by_id_done";
+        public const string IPCSetStateByIdDone = "ipc_set_state_by_id_done";
 
         public const string TemplateEditorActiveWarning = "template_editor_active_warn";
         public const string ClipboardDataUnsupported = "clipboard_data_unsupported_version";


### PR DESCRIPTION
- Adds IPC to adjust the priority of a profile
- Adds IPC to set both a profiles state and priority simultaneously.

Primarily added to grant more versatility when it comes to profile state management over IPC.

Followed the existing structure to make implementation fluid with new methods, and also added the respective IPC Test options for the new methods in `IPCTestTab`

_(Forgot to branch the PR of my fork so the update messed with the changes, this should have all corrected changes)_