### PR TITLE
Keep 'Propagate' options enabled while editing template

### DIFF
--- a/CustomizePlus/Core/Data/BoneTransform.cs
+++ b/CustomizePlus/Core/Data/BoneTransform.cs
@@ -78,6 +78,8 @@ public class BoneTransform
                || !Scaling.IsApproximately(Vector3.One, 0.00001f);
     }
 
+    public bool HasConfig() => PropagateRotation || PropagateScale || PropagateTranslation || this.IsEdited();
+
     public BoneTransform DeepCopy()
     {
         return new BoneTransform

--- a/CustomizePlus/Templates/TemplateManager.cs
+++ b/CustomizePlus/Templates/TemplateManager.cs
@@ -220,7 +220,7 @@ public class TemplateManager : IDisposable
             if (boneTransform == transform)
                 return false;
 
-            if (transform.IsEdited())
+            if (transform.HasConfig())
             {
                 template.Bones[boneName].UpdateToMatch(transform);
 
@@ -240,7 +240,7 @@ public class TemplateManager : IDisposable
         else
         {
 
-            if (!transform.IsEdited())
+            if (!transform.HasConfig())
                 return false;
 
             template.Bones[boneName] = new BoneTransform(transform);


### PR DESCRIPTION
This changes the behavior of the the template editor to not immediately remove bones with all zero transform if their propagate options are enabled, allowing values to cross zero while editing without resetting the options.

Unmodified bones will still be removed via `PruneIdempotentTransforms` regardless of the propagate settings.