### PR TITLE
Fix index tracking in AddTemporaryProfile() if existingProfile != null

### DIFF
--- a/CustomizePlus/Profiles/ProfileManager.cs
+++ b/CustomizePlus/Profiles/ProfileManager.cs
@@ -440,7 +440,6 @@ public partial class ProfileManager : IDisposable
         profile.Enabled = true;
         profile.ProfileType = ProfileType.Temporary;
         profile.Priority = int.MaxValue; //Make sure temporary profile is always at max priority
-        profile.Index = Profiles.Count;
 
         var permanentIdentifier = identifier.CreatePermanent();
         profile.Characters.Clear();
@@ -453,6 +452,7 @@ public partial class ProfileManager : IDisposable
             DeleteProfile(existingProfile);
         }
 
+        profile.Index = Profiles.Count; // capture index *after* potential DeleteProfile() above
         Profiles.Add(profile);
 
         _logger.Debug($"Added temporary profile for {permanentIdentifier}");


### PR DESCRIPTION
Every profile in `Profiles` has an `.Index` that points back to its position in `Profiles`. DeleteProfile() requires that the .Index match the position (`Profiles[profiles.Index] == profile`).

AddTemporaryProfile() set .Index = Profiles.Count on the new temporary profile, but it did so *before* deleting any existing profile. This led to the .Index being off by one, so subsequent DeleteProfile() calls would `return false`.

Reproduction steps:

1. Enable debug logging and debug mode for C+
1. In the IPC tester, copy current profile into memory
1. SetTemporaryProfileOnCharacter from memory
1. DeleteTemporaryProfileOnCharacter -> observe the "Removed temporary profile" log line
1. SetTemporaryProfileOnCharacter from memory
1. (Again) SetTemporaryProfileOnCharacter from memory
1. DeleteTemporaryProfileOnCharacter -> observe no "Removed temporary profile" log