### PR TITLE
Disable window sounds in PopupSystem

### DIFF
--- a/CustomizePlus/UI/Windows/PopupSystem.cs
+++ b/CustomizePlus/UI/Windows/PopupSystem.cs
@@ -34,6 +34,7 @@ public partial class PopupSystem : LunaWindow
 
         IsOpen = true;
         RespectCloseHotkey = false;
+        DisableWindowSounds = true;
         Collapsed = false;
         SizeConstraints = new WindowSizeConstraints
         {


### PR DESCRIPTION
The `PopupSystem` window plays a sound effect when it opens, which happens every time the game starts and the plugin loads.

The window open/close sound effects are a 3 year old Dalamud feature, which is sadly not enabled by default.
It can be enabled in the Dalamud Settings under Look & Feel -> Enable sound effects for plugin windows.

This PR adds a single line to disable window sounds for this popup.

Would be nice if we can disable this. Thanks! :v:

(I honestly don't know what git is doing there, lol. It's only one line more.^^)